### PR TITLE
Fix errors while attempting to parse '/'

### DIFF
--- a/sources/pmwebapi.go
+++ b/sources/pmwebapi.go
@@ -116,6 +116,12 @@ func typeLabel(units string, pcpType string, name string) string {
 func fixNaming(name string) string {
 	name = strings.ToLower(name)
 	switch {
+	case strings.Contains(name, "seconds / count"):
+		name = strings.Replace(name, "seconds / count", "seconds_per_count", -1)
+	case strings.Contains(name, "mbyte / seconds"):
+		name = strings.Replace(name, "mbyte / seconds", "megabytes_per_second", -1)
+	case strings.Contains(name, "byte / seconds"):
+		name = strings.Replace(name, "byte / seconds", "bytes_per_second", -1)
 	case strings.Contains(name, "seconds"), strings.Contains(name, "milliseconds"), strings.Contains(name, "nanoseconds"):
 	case strings.Contains(name, "nanosec"):
 		name = strings.Replace(name, "nanosec", "nanoseconds", -1)
@@ -137,6 +143,10 @@ func fixNaming(name string) string {
 		name = strings.Replace(name, "byte", "bytes", -1)
 	case strings.Contains(name, "failcnt"):
 		name = strings.Replace(name, "failcnt", "failcount", -1)
+	case strings.Contains(name, " / "):
+		name = strings.Replace(name, " / ", "_per_", -1)
+	case strings.Contains(name, "/"):
+		name = strings.Replace(name, "/", "_per_", -1)
 	}
 	return strings.Replace(name, ".", "_", -1)
 }

--- a/sources/pmwebapi.go
+++ b/sources/pmwebapi.go
@@ -102,7 +102,10 @@ func unmarshal(text []byte, t interface{}) {
 
 func typeLabel(units string, pcpType string, name string) string {
 	unit := ""
-	if units != "" {
+	switch {
+	case strings.HasPrefix(units, "/ "):
+		unit = strings.Replace(units, "/ ", "_", 1)
+	case units != "":
 		unit = "_" + units
 	}
 	if strings.ToUpper(pcpType) == "COUNTER" {
@@ -116,12 +119,6 @@ func typeLabel(units string, pcpType string, name string) string {
 func fixNaming(name string) string {
 	name = strings.ToLower(name)
 	switch {
-	case strings.Contains(name, "seconds / count"):
-		name = strings.Replace(name, "seconds / count", "seconds_per_count", -1)
-	case strings.Contains(name, "mbyte / seconds"):
-		name = strings.Replace(name, "mbyte / seconds", "megabytes_per_second", -1)
-	case strings.Contains(name, "byte / seconds"):
-		name = strings.Replace(name, "byte / seconds", "bytes_per_second", -1)
 	case strings.Contains(name, "seconds"), strings.Contains(name, "milliseconds"), strings.Contains(name, "nanoseconds"):
 	case strings.Contains(name, "nanosec"):
 		name = strings.Replace(name, "nanosec", "nanoseconds", -1)
@@ -147,6 +144,14 @@ func fixNaming(name string) string {
 		name = strings.Replace(name, " / ", "_per_", -1)
 	case strings.Contains(name, "/"):
 		name = strings.Replace(name, "/", "_per_", -1)
+	}
+	switch {
+	case strings.Contains(name, "seconds / count"):
+		name = strings.Replace(name, "seconds / count", "seconds_per_count", -1)
+	case strings.Contains(name, "mbyte / seconds"):
+		name = strings.Replace(name, "mbyte / seconds", "megabytes_per_second", -1)
+	case strings.Contains(name, "byte / seconds"):
+		name = strings.Replace(name, "byte / seconds", "bytes_per_second", -1)
 	}
 	return strings.Replace(name, ".", "_", -1)
 }

--- a/sources/pmwebapi_test.go
+++ b/sources/pmwebapi_test.go
@@ -87,6 +87,9 @@ func TestWeirdMetrics(t *testing.T) {
 	name["pcp_network_interface_baudrate_byte / seconds"] = "pcp_network_interface_baudrate_bytes_per_second"
 	name["pcp_network_interface_speed_mbyte / seconds"] = "pcp_network_interface_speed_megabytes_per_second"
 	name["pcp_pmcd_cputime_per_pdu_in_microseconds / count"] = "pcp_pmcd_cputime_per_pdu_in_microseconds_per_count"
+	name["pcp_network_interface_baudrate_byte / sec"] = "pcp_network_interface_baudrate_bytes_per_second"
+	name["pcp_network_interface_speed_mbyte / sec"] = "pcp_network_interface_speed_megabytes_per_second"
+	name["pcp_pmcd_cputime_per_pdu_in_microsec / count"] = "pcp_pmcd_cputime_per_pdu_in_microseconds_per_count"
 	name["something_unexpected / unit"] = "something_unexpected_per_unit"
 	name["another_unexpected/unit"] = "another_unexpected_per_unit"
 
@@ -105,6 +108,8 @@ func TestLabelTypes(t *testing.T) {
 		{"", "", "", ""},
 		{"kal", "CoUnTeR", "kal", "kal_kal_total"},
 		{"tery", "gagage", "kall", "kall_tery"},
+		{"/ tery", "gagage", "kall", "kall_tery"},
+		{"/ kal", "CoUnTeR", "kal", "kal_kal_total"},
 	}
 
 	for _, element := range arr {

--- a/sources/pmwebapi_test.go
+++ b/sources/pmwebapi_test.go
@@ -84,6 +84,11 @@ func TestWeirdMetrics(t *testing.T) {
 	name["kal_byte"] = "kal_bytes"
 	name["gorgi_nanosec"] = "gorgi_nanoseconds"
 	name["asfdasfr_Mbyte"] = "asfdasfr_megabytes"
+	name["pcp_network_interface_baudrate_byte / seconds"] = "pcp_network_interface_baudrate_bytes_per_second"
+	name["pcp_network_interface_speed_mbyte / seconds"] = "pcp_network_interface_speed_megabytes_per_second"
+	name["pcp_pmcd_cputime_per_pdu_in_microseconds / count"] = "pcp_pmcd_cputime_per_pdu_in_microseconds_per_count"
+	name["something_unexpected / unit"] = "something_unexpected_per_unit"
+	name["another_unexpected/unit"] = "another_unexpected_per_unit"
 
 	for key, val := range name {
 		converted := fixNaming(key)


### PR DESCRIPTION
Certain metrics fell-through the fixNaming switch while keeping a
'/' character which threw errors while attempting to parse the
metric. The fixNaming function has been updated to handle the
specific cases that were seen causing this issue, while also
introducing a fallback in case another metric unexpectedly has a
'/' in it.

Fixes #24

Signed-Off-By: Robert Clark <robert.d.clark@hpe.com>