### PR TITLE
fix parse issue

### DIFF
--- a/sources/pmwebapi.go
+++ b/sources/pmwebapi.go
@@ -102,7 +102,10 @@ func unmarshal(text []byte, t interface{}) {
 
 func typeLabel(units string, pcpType string, name string) string {
 	unit := ""
-	if units != "" {
+	switch {
+	case strings.HasPrefix(units, "/ "):
+		unit = strings.Replace(units, "/ ", "_", 1)
+	case units != "":
 		unit = "_" + units
 	}
 	if strings.ToUpper(pcpType) == "COUNTER" {
@@ -116,12 +119,6 @@ func typeLabel(units string, pcpType string, name string) string {
 func fixNaming(name string) string {
 	name = strings.ToLower(name)
 	switch {
-	case strings.Contains(name, "seconds / count"):
-		name = strings.Replace(name, "seconds / count", "seconds_per_count", -1)
-	case strings.Contains(name, "mbyte / seconds"):
-		name = strings.Replace(name, "mbyte / seconds", "megabytes_per_second", -1)
-	case strings.Contains(name, "byte / seconds"):
-		name = strings.Replace(name, "byte / seconds", "bytes_per_second", -1)
 	case strings.Contains(name, "seconds"), strings.Contains(name, "milliseconds"), strings.Contains(name, "nanoseconds"):
 	case strings.Contains(name, "nanosec"):
 		name = strings.Replace(name, "nanosec", "nanoseconds", -1)
@@ -147,6 +144,14 @@ func fixNaming(name string) string {
 		name = strings.Replace(name, " / ", "_per_", -1)
 	case strings.Contains(name, "/"):
 		name = strings.Replace(name, "/", "_per_", -1)
+	}
+	switch {
+	case strings.Contains(name, "seconds / count"):
+		name = strings.Replace(name, "seconds / count", "seconds_per_count", -1)
+	case strings.Contains(name, "mbyte / seconds"):
+		name = strings.Replace(name, "mbyte / seconds", "megabytes_per_second", -1)
+	case strings.Contains(name, "byte / seconds"):
+		name = strings.Replace(name, "byte / seconds", "bytes_per_second", -1)
 	}
 	return strings.Replace(name, ".", "_", -1)
 }

--- a/sources/pmwebapi_test.go
+++ b/sources/pmwebapi_test.go
@@ -87,6 +87,9 @@ func TestWeirdMetrics(t *testing.T) {
 	name["pcp_network_interface_baudrate_byte / seconds"] = "pcp_network_interface_baudrate_bytes_per_second"
 	name["pcp_network_interface_speed_mbyte / seconds"] = "pcp_network_interface_speed_megabytes_per_second"
 	name["pcp_pmcd_cputime_per_pdu_in_microseconds / count"] = "pcp_pmcd_cputime_per_pdu_in_microseconds_per_count"
+	name["pcp_network_interface_baudrate_byte / sec"] = "pcp_network_interface_baudrate_bytes_per_second"
+	name["pcp_network_interface_speed_mbyte / sec"] = "pcp_network_interface_speed_megabytes_per_second"
+	name["pcp_pmcd_cputime_per_pdu_in_microsec / count"] = "pcp_pmcd_cputime_per_pdu_in_microseconds_per_count"
 	name["something_unexpected / unit"] = "something_unexpected_per_unit"
 	name["another_unexpected/unit"] = "another_unexpected_per_unit"
 
@@ -105,6 +108,8 @@ func TestLabelTypes(t *testing.T) {
 		{"", "", "", ""},
 		{"kal", "CoUnTeR", "kal", "kal_kal_total"},
 		{"tery", "gagage", "kall", "kall_tery"},
+		{"/ tery", "gagage", "kall", "kall_tery"},
+		{"/ kal", "CoUnTeR", "kal", "kal_kal_total"},
 	}
 
 	for _, element := range arr {


### PR DESCRIPTION
@roclark 
I believe this problem is due to the fact that its within the same switch statement that takes `sec` and replaces to `seconds` and `mbyte` to `megabytes` etc... You can just bump this fix down below the first switch statement into its own switch statement and it should fix it.

## Example

```
	switch {
	case strings.Contains(name, "seconds"), strings.Contains(name, "milliseconds"), strings.Contains(name, "nanoseconds"):
	case strings.Contains(name, "nanosec"):
		name = strings.Replace(name, "nanosec", "nanoseconds", -1)
	case strings.Contains(name, "millisec"):
		name = strings.Replace(name, "millisec", "milliseconds", -1)
	case strings.Contains(name, "count / sec"):
		name = strings.Replace(name, "count / sec", "count_per_second", -1)
	case strings.Contains(name, "sec"):
		name = strings.Replace(name, "sec", "seconds", -1)
	case strings.Contains(name, "mbyte"):
		name = strings.Replace(name, "mbyte", "megabytes", -1)
	case strings.Contains(name, "kbyte"):
		name = strings.Replace(name, "kbyte", "kilobytes", -1)
	case strings.Contains(name, "kilobytes"), strings.Contains(name, "megabytes"):
	case strings.Contains(name, "bytes_byte"):
		name = strings.Replace(name, "bytes_byte", "bytes", -1)
	case strings.Contains(name, "bytes"):
	case strings.Contains(name, "byte"):
		name = strings.Replace(name, "byte", "bytes", -1)
	case strings.Contains(name, "failcnt"):
		name = strings.Replace(name, "failcnt", "failcount", -1)
	}
	switch {
	case strings.Contains(name, "seconds / count"):
		name = strings.Replace(name, "seconds / count", "seconds_per_count", -1)
	case strings.Contains(name, "mbyte / seconds"):
		name = strings.Replace(name, "mbyte / seconds", "megabytes_per_second", -1)
	case strings.Contains(name, "byte / seconds"):
		name = strings.Replace(name, "byte / seconds", "bytes_per_second", -1)
	}
```

## I also found another small BUG but it could be from my pcp version `3.12.2`.

The cpu clock had a weird unit format in PCP `/ microsec`
```
        {
            "name": "hinv.cpu.clock",
            "text-oneline": "clock rate in Mhz for each CPU as reported by /proc/cpuinfo",
            "text-help": "clock rate in Mhz for each CPU as reported by /proc/cpuinfo",
            "pmid": 251676672,
            "indom": 251658240,
            "sem": "discrete",
            "units": "/ microsec",
            "type": "FLOAT"
        }
```

To fix this I went ahead and added a switch into the `TypeLabel` function
The function replaces `/ ` in the unit field with `_`, this only applies if `/ ` is at the beginning of the units string.
```
	switch {
	case strings.HasPrefix(units, "/ "):
		unit = strings.Replace(units, "/ ", "_", 1)
	case units != "":
		unit = "_" + units
	}
```

Here is a PR for this fix.